### PR TITLE
Add support for n arguments to `run`

### DIFF
--- a/lib/breaker.js
+++ b/lib/breaker.js
@@ -35,31 +35,39 @@ Breaker.State = Object.freeze({
 });
 
 
-Breaker.prototype.run = function run(context, callback) {
-    var self, fallback, fn;
+Breaker.prototype.run = function run(/*args...n, callback*/) {
+    var args, self, fallback, orig;
 
+    args = Array.prototype.slice.call(arguments);
     self = this;
     fallback = this.fallback;
-    fn = callback;
 
     if (fallback instanceof Breaker) {
-        fn = function wrapper(err/*, ...data*/) {
+        orig = args.slice();
+        args[args.length - 1] = function wrapper(err/*, ...data*/) {
+            var callback;
+
             if (err && self.isOpen()) {
-                fallback.run(context, callback);
+                fallback.run.apply(fallback, orig);
                 return;
             }
+
+            callback = orig.pop();
             callback.apply(null, arguments);
         };
     }
 
-    this._run(context, fn);
+    this._run.apply(this, args);
 };
 
 
-Breaker.prototype._run = function _run(context, callback) {
-    var self, start, timer, execute;
+Breaker.prototype._run = function _run(/*args...n, callback*/) {
+    var args, callback, self, start, timer, execute;
 
     this.emit('execute');
+
+    args = Array.prototype.slice.call(arguments);
+    callback = args.pop();
 
     if (this.isOpen() || this._pendingClose) {
         this.emit('reject');
@@ -92,8 +100,7 @@ Breaker.prototype._run = function _run(context, callback) {
 
     timer.unref();
 
-    execute = Zalgo.contain(this._impl.execute, this._impl);
-    execute(context, function onreponse(err/*, ...data*/) {
+    args[args.length] = function onreponse(err/*, ...data*/) {
         if (!timer) { return; }
 
         clearTimeout(timer);
@@ -111,7 +118,11 @@ Breaker.prototype._run = function _run(context, callback) {
         }
 
         callback.apply(null, arguments);
-    });
+    };
+
+
+    execute = Zalgo.contain(this._impl.execute, this._impl);
+    execute.apply(null, args);
 };
 
 


### PR DESCRIPTION
Previously, `run` (and the implementation to be wrapped by levee) only accepted a single context argument and callback function. This change allows n arguments in addition to the callback, e.g.:

``` javascript
var circuit = levee.createBreaker(function (foo, bar, baz, cb) {
    // use foo, bar, and baz
    cb();
});

circuit.run('foo', 'bar', 'baz', function (err) {
   console.log(err || 'ok');
});
```
