### PR TITLE
support for streams

### DIFF
--- a/lib/ProxyStream.js
+++ b/lib/ProxyStream.js
@@ -1,0 +1,30 @@
+var util = require('util');
+var stream = require('stream');
+
+var ProxyStream = function () {
+	stream.PassThrough.call(this);
+	this._headers = {};
+	this._destroyed = false;
+};
+
+util.inherits(ProxyStream, stream.PassThrough);
+
+ProxyStream.prototype.setHeader = function (name, value) {
+	this._headers[name] = value;
+};
+
+ProxyStream.prototype.destroy = function (err) {
+	if (this._destroyed){
+		return;
+	}
+	this._destroyed = true;
+	var self = this;
+	process.nextTick(function () {
+		if (err) {
+			self.emit('error', err);
+		}
+		self.emit('close');
+	});
+};
+
+module.exports = ProxyStream;

--- a/lib/breaker.js
+++ b/lib/breaker.js
@@ -7,6 +7,7 @@ var Assert = require('assert');
 var eos = require('end-of-stream');
 var Zalgo = require('./zalgo');
 var Defaults = require('./defaults');
+var ProxyStream = require('./ProxyStream');
 
 
 function Breaker(impl, options) {
@@ -74,10 +75,16 @@ Breaker.prototype._run = function _run(/*args...n, callback*/) {
 
     if (this.isOpen() || this._pendingClose) {
         this.emit('reject');
-        var err = new Error('Command not available.');
+        var err = new Error('Circuit breaker forced failure. It will stop forcing failures once calls start succeeding');
+        err.args = args;
         err.code = 1000;
-        callback && callback(err);
-        return;
+        if(callback){
+            return callback(err);
+        } else {
+            var s = new ProxyStream();
+            s.destroy(err);
+            return s;
+        }
     }
 
     if (this.isHalfOpen()) {

--- a/lib/breaker.js
+++ b/lib/breaker.js
@@ -74,7 +74,9 @@ Breaker.prototype._run = function _run(/*args...n, callback*/) {
 
     if (this.isOpen() || this._pendingClose) {
         this.emit('reject');
-        callback && callback(new Error('Command not available.'));
+        var err = new Error('Command not available.');
+        err.code = 1000;
+        callback && callback(err);
         return;
     }
 

--- a/lib/breaker.js
+++ b/lib/breaker.js
@@ -4,6 +4,7 @@ var Util = require('util');
 var Hoek = require('hoek');
 var Events = require('events');
 var Assert = require('assert');
+var eos = require('end-of-stream');
 var Zalgo = require('./zalgo');
 var Defaults = require('./defaults');
 
@@ -42,7 +43,7 @@ Breaker.prototype.run = function run(/*args...n, callback*/) {
     self = this;
     fallback = this.fallback;
 
-    if (fallback instanceof Breaker) {
+    if (fallback instanceof Breaker && typeof args[args.length - 1] === 'function') {
         orig = args.slice();
         args[args.length - 1] = function wrapper(err/*, ...data*/) {
             var callback;
@@ -57,7 +58,7 @@ Breaker.prototype.run = function run(/*args...n, callback*/) {
         };
     }
 
-    this._run.apply(this, args);
+    return this._run.apply(this, args);
 };
 
 
@@ -67,11 +68,13 @@ Breaker.prototype._run = function _run(/*args...n, callback*/) {
     this.emit('execute');
 
     args = Array.prototype.slice.call(arguments);
-    callback = args.pop();
+    if (typeof args[args.length - 1] === 'function') {
+        callback = args.pop();
+    }
 
     if (this.isOpen() || this._pendingClose) {
         this.emit('reject');
-        callback(new Error('Command not available.'));
+        callback && callback(new Error('Command not available.'));
         return;
     }
 
@@ -89,20 +92,31 @@ Breaker.prototype._run = function _run(/*args...n, callback*/) {
     start = Date.now();
 
     timer = setTimeout(function ontimeout() {
-        var error = new Error('Command timeout.');
-        error.name = 'commandTimeout';
-        error.code = 'ETIMEDOUT';
+
         timer = undefined;
         self._pendingClose = false;
         self.emit('timeout');
         self._onFailure();
-        callback(error);
+        callback && callback(new Error('Command timeout.'));
+
     }, this.settings.timeout);
 
     timer.unref();
 
-    args[args.length] = function onreponse(err/*, ...data*/) {
-        if (!timer) { return; }
+    if (callback) {
+        args[args.length] = onresponse;
+    }
+    execute = Zalgo.contain(this._impl.execute, this._impl);
+    var stream = execute.apply(null, args);
+    if(!callback){
+        eos(stream, onresponse);
+    }
+    return stream;
+
+    function onresponse(err/*, ...data*/) {
+        if (!timer) {
+            return;
+        }
 
         clearTimeout(timer);
         timer = undefined;
@@ -118,12 +132,8 @@ Breaker.prototype._run = function _run(/*args...n, callback*/) {
             self.close();
         }
 
-        callback.apply(null, arguments);
-    };
-
-
-    execute = Zalgo.contain(this._impl.execute, this._impl);
-    execute.apply(null, args);
+        callback && callback.apply(null, arguments);
+    }
 };
 
 

--- a/lib/breaker.js
+++ b/lib/breaker.js
@@ -64,7 +64,7 @@ Breaker.prototype.run = function run(/*args...n, callback*/) {
 
 
 Breaker.prototype._run = function _run(/*args...n, callback*/) {
-    var args, callback, self, start, timer, execute;
+    var args, callback, self, start, timer, execute, err, stream;
 
     this.emit('execute');
 
@@ -75,7 +75,7 @@ Breaker.prototype._run = function _run(/*args...n, callback*/) {
 
     if (this.isOpen() || this._pendingClose) {
         this.emit('reject');
-        var err = new Error('Circuit breaker forced failure. It will stop forcing failures once calls start succeeding');
+        err = new Error('Circuit breaker forced failure. It will stop forcing failures once calls start succeeding');
         err.args = args;
         err.code = 1000;
         if(callback){
@@ -106,8 +106,14 @@ Breaker.prototype._run = function _run(/*args...n, callback*/) {
         self._pendingClose = false;
         self.emit('timeout');
         self._onFailure();
-        callback && callback(new Error('Command timeout.'));
-
+        var err = new Error('Circuit breaker timed out');
+        err.args = args;
+        err.code = 1100;
+        if(callback){
+            callback(err);
+        } else if(stream){
+            stream.destroy(err);            
+        }
     }, this.settings.timeout);
 
     timer.unref();
@@ -116,7 +122,7 @@ Breaker.prototype._run = function _run(/*args...n, callback*/) {
         args[args.length] = onresponse;
     }
     execute = Zalgo.contain(this._impl.execute, this._impl);
-    var stream = execute.apply(null, args);
+    stream = execute.apply(null, args);
     if(!callback){
         eos(stream, onresponse);
     }

--- a/lib/zalgo.js
+++ b/lib/zalgo.js
@@ -20,12 +20,12 @@ exports.contain = function contain(fn, context) {
 
         // Defend against re-wrapping callbacks
         callback = arguments[arguments.length - 1];
-        if (callback.name !== __container__.name) {
+        if (typeof callback === 'function' && callback.name !== __container__.name) {
             arguments[arguments.length - 1] = __container__;
         }
 
         sync = true;
-        fn.apply(context || this, arguments);
+        return fn.apply(context || this, arguments);
         sync = false;
     };
 };

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "wreck": "^3.0.0"
   },
   "dependencies": {
+    "end-of-stream": "^1.1.0",
     "hoek": "^2.4.1"
   },
   "repository": {

--- a/test/breaker.js
+++ b/test/breaker.js
@@ -189,7 +189,7 @@ test('timeout', function (t) {
 
     breaker.run('ok', function (err, data) {
         t.ok(err);
-        t.equal(err.message, 'Command timeout.');
+        t.equal(err.message, 'Circuit breaker timed out');
         t.notOk(data);
         t.ok(breaker.isOpen());
         t.end();

--- a/test/breaker.js
+++ b/test/breaker.js
@@ -119,7 +119,7 @@ test('failure', function (t) {
 
         breaker.run('not ok', function (err, data) {
             t.ok(err);
-            t.equal(err.message, 'Command not available.');
+            t.equal(err.message, 'Circuit breaker forced failure. It will stop forcing failures once calls start succeeding');
             t.notOk(data);
             t.ok(breaker.isOpen());
             t.end();


### PR DESCRIPTION
This let's you do request streaming with the `request` module. I'm using this branch in [circuit-breaker-request](https://github.com/debitoor/circuit-breaker-request#readme). That I'm currently working on. And I have all tests green there.
This Fixes #10 
