### PR TITLE
Made callbacks optional and return results from function called. 

### DIFF
--- a/lib/breaker.js
+++ b/lib/breaker.js
@@ -53,26 +53,29 @@ Breaker.prototype.run = function run(/*args...n, callback*/) {
             }
 
             callback = orig.pop();
+
             callback.apply(null, arguments);
         };
     }
 
-    this._run.apply(this, args);
+    return this._run.apply(this, args);
 };
 
 
 Breaker.prototype._run = function _run(/*args...n, callback*/) {
-    var args, callback, self, start, timer, execute;
+    var args, callback, self, start, timer, execute, error;
 
     this.emit('execute');
 
     args = Array.prototype.slice.call(arguments);
+
     callback = args.pop();
 
     if (this.isOpen() || this._pendingClose) {
-        this.emit('reject');
-        callback(new Error('Command not available.'));
-        return;
+        error = new Error('Command not available.');
+        this.emit('reject', error);
+        callback(error);
+        return null;
     }
 
     if (this.isHalfOpen()) {
@@ -94,15 +97,19 @@ Breaker.prototype._run = function _run(/*args...n, callback*/) {
         error.code = 'ETIMEDOUT';
         timer = undefined;
         self._pendingClose = false;
-        self.emit('timeout');
+        self.emit('timeout', error);
         self._onFailure();
         callback(error);
     }, this.settings.timeout);
 
     timer.unref();
 
-    args[args.length] = function onreponse(err/*, ...data*/) {
-        if (!timer) { return; }
+    args[args.length] = function onreponse(err /*,...data*/) {
+        var results = Array.prototype.slice.call(arguments, 1);
+
+        if (!timer) {
+            return;
+        }
 
         clearTimeout(timer);
         timer = undefined;
@@ -114,7 +121,8 @@ Breaker.prototype._run = function _run(/*args...n, callback*/) {
             self.emit('failure', err);
             self._onFailure();
         } else {
-            self.emit('success');
+            results.unshift('success');
+            self.emit.apply(self, results);
             self.close();
         }
 
@@ -123,7 +131,8 @@ Breaker.prototype._run = function _run(/*args...n, callback*/) {
 
 
     execute = Zalgo.contain(this._impl.execute, this._impl);
-    execute.apply(null, args);
+
+    return execute.apply(null, args);
 };
 
 

--- a/lib/zalgo.js
+++ b/lib/zalgo.js
@@ -3,7 +3,7 @@
 
 exports.contain = function contain(fn, context) {
     return function zalgo() {
-        var callback, sync;
+        var callback, sync, result;
 
         function __container__() {
             var args;
@@ -25,7 +25,8 @@ exports.contain = function contain(fn, context) {
         }
 
         sync = true;
-        fn.apply(context || this, arguments);
+        result = fn.apply(context || this, arguments);
         sync = false;
+        return result;
     };
 };

--- a/test/breaker.js
+++ b/test/breaker.js
@@ -127,6 +127,18 @@ test('failure', function (t) {
     });
 });
 
+test('test return value', function (t) {
+    t.plan(1);
+
+    var breaker = new Breaker({
+        execute: function (arg, callback) {
+            callback();
+            return arg;
+        }
+    });
+
+    t.equal(breaker.run('ok', function () {}), 'ok');
+});
 
 test('fallback', function (t) {
     var breaker, fallback;


### PR DESCRIPTION
This is to enable a case where, for example, the underlying function has an optional callback and returns and/or returns and object such as the request object in the case of http core libraries.