### PR TITLE
feat: made isFailure work for timeout errors

### DIFF
--- a/lib/breaker.js
+++ b/lib/breaker.js
@@ -98,7 +98,9 @@ Breaker.prototype._run = function _run(/*args...n, callback*/) {
         timer = undefined;
         self._pendingClose = false;
         self.emit('timeout', error);
-        self._onFailure();
+
+        if (self.settings.isFailure(error)) self._onFailure();
+        
         callback(error);
     }, this.settings.timeout);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "levee",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/breaker.js
+++ b/test/breaker.js
@@ -202,6 +202,28 @@ test('timeout', function (t) {
     });
 });
 
+test('timeout with custom failure check', function (t) {
+    var breaker;
+
+    breaker = new Breaker(timeout, {
+        isFailure: function () {
+            return false;
+        },
+        timeout: 10,
+        maxFailures: 1
+    });
+
+    t.ok(breaker.isClosed());
+
+    breaker.run('ok', function (err, data) {
+        t.ok(err);
+        t.equal(err.message, 'Command timeout.');
+        t.notOk(data);
+        t.ok(breaker.isClosed());
+        t.end();
+    });
+});
+
 test('timeout returned value', function(t){
     var breaker;
     breaker = new Breaker(timeoutCallback, {timeout: 10, maxFailures: 1});


### PR DESCRIPTION
Previously, timeout errors would always count as a failure and trigger the circuit breaker.

This is problematic when certain APIs are expected to (sometimes) time out.

**Yes, this is bad design. No, there's not that much that can be done when it's an external API.**

I have added support for timeout errors to be included in `isFailure`, and added a basic test to support this. Please feel free to make suggestions / changes as required! Thanks 😄 

Relevant issue: https://github.com/krakenjs/levee/issues/30